### PR TITLE
feat: Implementa Fase 3 - Compartilhamento Social das Avaliações

### DIFF
--- a/src/components/features/sharing/SharePreviewModal.jsx
+++ b/src/components/features/sharing/SharePreviewModal.jsx
@@ -1,0 +1,160 @@
+// src/components/features/sharing/SharePreviewModal.jsx
+import React, { useEffect, useRef } from 'react';
+import ShareableReviewCard from './ShareableReviewCard';
+import { X, Download, Twitter, ShareNetwork, Loader2 } from 'lucide-react';
+
+const SharePreviewModal = ({
+  isOpen,
+  onClose,
+  animeDetails,
+  userReview,
+  currentTheme,
+  generatedImage,
+  isGenerating,
+  imageError,
+  onGenerateImage // Função que chama generateImage(ref) do hook
+}) => {
+  const cardToCaptureRef = useRef(null);
+
+  useEffect(() => {
+    // Gera a imagem quando o modal abre, o card está referenciado,
+    // e ainda não temos uma imagem, nem estamos gerando, nem temos um erro.
+    if (isOpen && cardToCaptureRef.current && !generatedImage && !isGenerating && !imageError) {
+      onGenerateImage(cardToCaptureRef.current);
+    }
+  }, [isOpen, generatedImage, isGenerating, imageError, onGenerateImage, animeDetails, userReview, currentTheme]);
+  // Adicionado animeDetails, userReview, currentTheme às dependências para garantir que
+  // se o modal permanecer aberto e esses dados mudarem (improvável neste fluxo, mas bom para robustez),
+  // uma nova imagem possa ser considerada para geração.
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleDownload = () => {
+    if (!generatedImage) return;
+    const link = document.createElement('a');
+    link.href = generatedImage;
+    link.download = `anime-master-review-${animeDetails?.title?.replace(/[^a-z0-9]/gi, '_').toLowerCase() || 'share'}.png`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  const handleTwitterShare = () => {
+    if (!animeDetails || !userReview) return;
+    const text = encodeURIComponent(
+      `Confira minha avaliação de ${animeDetails.title}! Nota: ${userReview.rating}/5. ${userReview.opinion ? `Opinião: "${userReview.opinion.substring(0,50)}..." ` : ''}#AnimeMaster #${animeDetails.title?.replace(/\s+/g, '')}`
+    );
+    const twitterUrl = `https://twitter.com/intent/tweet?text=${text}`;
+    window.open(twitterUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleWebShare = async () => {
+    if (!generatedImage || typeof window === 'undefined' || !navigator.share) return;
+    try {
+      const response = await fetch(generatedImage);
+      const blob = await response.blob();
+      const file = new File([blob], `anime-master-review-${animeDetails?.title?.replace(/[^a-z0-9]/gi, '_').toLowerCase() || 'share'}.png`, { type: 'image/png' });
+
+      if (navigator.canShare && navigator.canShare({ files: [file] })) {
+        await navigator.share({
+          files: [file],
+          title: `Minha avaliação de ${animeDetails.title}`,
+          text: `Confira minha avaliação de ${animeDetails.title} (${userReview.rating}/5) feita no Anime Master!`,
+        });
+      } else {
+        alert("Seu navegador não suporta compartilhar esta imagem diretamente. Tente baixar a imagem e compartilhar manualmente.");
+      }
+    } catch (error) {
+      console.error('Erro ao usar Web Share API:', error);
+      alert('Erro ao tentar compartilhar. Tente baixar a imagem.');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center p-4 z-[100] backdrop-blur-sm" onClick={onClose}>
+      <div
+        className="bg-card-light dark:bg-card-dark rounded-xl shadow-2xl p-6 w-full max-w-md max-h-[90vh] overflow-y-auto relative"
+        onClick={(e) => e.stopPropagation()} // Impede que o clique dentro do modal o feche
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 p-1.5 rounded-full text-text-muted-light dark:text-text-muted-dark hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+          aria-label="Fechar modal"
+        >
+          <X size={24} />
+        </button>
+
+        <h2 className="text-2xl font-bold text-text-main-light dark:text-text-main-dark mb-4 text-center">
+          Compartilhar Avaliação
+        </h2>
+
+        {/* Este div é para renderizar o ShareableReviewCard APENAS para captura, oculto da visão principal do modal */}
+        {/* Ele é necessário no DOM para que html2canvas possa capturá-lo */}
+        {isOpen && !generatedImage && !isGenerating && !imageError && (
+             <div className="absolute -left-[9999px] -top-[9999px] opacity-0 pointer-events-none">
+                 <ShareableReviewCard
+                     ref={cardToCaptureRef}
+                     animeDetails={animeDetails}
+                     userReview={userReview}
+                     currentTheme={currentTheme}
+                 />
+             </div>
+         )}
+
+        {isGenerating && (
+          <div className="my-8 flex flex-col items-center justify-center text-center min-h-[200px]">
+            <Loader2 size={48} className="animate-spin text-primary-light dark:text-primary-dark mb-3" />
+            <p className="text-text-muted-light dark:text-text-muted-dark">Gerando sua imagem...</p>
+          </div>
+        )}
+
+        {imageError && !isGenerating && (
+          <div className="my-8 text-center p-4 bg-red-100 dark:bg-red-700/30 rounded-md min-h-[200px] flex flex-col justify-center">
+            <p className="text-red-700 dark:text-red-300 font-medium">Erro ao gerar imagem:</p>
+            <p className="text-red-600 dark:text-red-400 text-sm">{imageError}</p>
+            <button
+              onClick={() => onGenerateImage(cardToCaptureRef.current)}
+              className="mt-4 px-4 py-2 bg-primary-light text-white rounded-md hover:bg-opacity-80 text-sm"
+            >
+              Tentar Novamente
+            </button>
+          </div>
+        )}
+
+        {generatedImage && !isGenerating && (
+          <div className="my-4">
+            <img src={generatedImage} alt="Prévia da avaliação gerada" className="rounded-lg shadow-md mx-auto border border-gray-300 dark:border-gray-600 max-w-full" />
+          </div>
+        )}
+
+        {generatedImage && !isGenerating && (
+          <div className="mt-6 space-y-3">
+            <button
+              onClick={handleDownload}
+              className="w-full flex items-center justify-center bg-green-600 hover:bg-green-700 text-white font-bold py-2.5 px-4 rounded-lg shadow-md transition-colors"
+            >
+              <Download size={18} className="mr-2" /> Baixar Imagem
+            </button>
+            <button
+              onClick={handleTwitterShare}
+              className="w-full flex items-center justify-center bg-[#1DA1F2] hover:bg-[#1A91DA] text-white font-bold py-2.5 px-4 rounded-lg shadow-md transition-colors"
+            >
+              <Twitter size={18} className="mr-2" /> Compartilhar no Twitter
+            </button>
+            {typeof window !== 'undefined' && navigator.share && navigator.canShare && (
+              <button
+                onClick={handleWebShare}
+                className="w-full flex items-center justify-center bg-gray-600 hover:bg-gray-700 text-white font-bold py-2.5 px-4 rounded-lg shadow-md transition-colors"
+              >
+                <ShareNetwork size={18} className="mr-2" /> Compartilhar (Nativo)
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+export default SharePreviewModal;

--- a/src/components/features/sharing/ShareableReviewCard.jsx
+++ b/src/components/features/sharing/ShareableReviewCard.jsx
@@ -1,0 +1,117 @@
+// src/components/features/sharing/ShareableReviewCard.jsx
+import React from 'react';
+import { Star } from 'lucide-react'; // Reutilizar o ícone de estrela
+
+const ShareableReviewCard = React.forwardRef(({ animeDetails, userReview, currentTheme }, ref) => {
+  // Adicionado currentTheme como prop para aplicar estilos de fundo e texto explicitamente
+  // já que html2canvas pode não capturar o tema do <html> corretamente em todos os cenários.
+
+  if (!animeDetails || !userReview) {
+    return (
+        <div
+            ref={ref}
+            className="w-[400px] h-[300px] flex items-center justify-center text-gray-400 border border-gray-300 rounded-xl shadow-2xl"
+            style={{ backgroundColor: currentTheme === 'dark' ? '#1F2937' : '#FFFFFF' }} // Fundo explícito
+        >
+            Carregando dados da avaliação...
+        </div>
+    );
+  }
+
+  const { title, images } = animeDetails;
+  const { rating, opinion } = userReview;
+
+  const maxOpinionLength = 150;
+  const truncatedOpinion = opinion && opinion.length > maxOpinionLength
+    ? `${opinion.substring(0, maxOpinionLength)}...`
+    : opinion;
+
+  const renderStars = (currentRating) => {
+    const totalStars = 5;
+    let stars = [];
+    for (let i = 1; i <= totalStars; i++) {
+      stars.push(
+        <Star
+          key={i}
+          size={24}
+          // Aplicar cores explícitas para estrelas com base no tema e rating
+          fill={currentRating >= i ? '#FFC107' : (currentTheme === 'dark' ? '#4B5563' : '#E5E7EB')} // fill-yellow-400 or fill-gray-500/300
+          stroke={currentRating >= i ? '#FFC107' : (currentTheme === 'dark' ? '#6B7280' : '#D1D5DB')} // text-yellow-400 or text-gray-500/400
+          className={currentRating >= i ? '' : ''} // Remover classes de cor Tailwind para não conflitarem com fill/stroke SVG
+        />
+      );
+    }
+    return <div className="flex justify-center my-3">{stars}</div>; // Ajustado my-2 para my-3
+  };
+
+  // Define cores explícitas para texto com base no tema
+  const textColor = currentTheme === 'dark' ? '#F3F4F6' : '#1F2937'; // text-main-dark / text-main-light
+  const mutedTextColor = currentTheme === 'dark' ? '#9CA3AF' : '#6B7280'; // text-muted-dark / text-muted-light
+  const primaryColor = currentTheme === 'dark' ? '#8B5CF6' : '#6D28D9'; // primary-dark / primary-light
+  const opinionBgColor = currentTheme === 'dark' ? '#374151' : '#F9FAFB'; // gray-700 (um pouco mais escuro que card-dark) / gray-50
+
+  return (
+    <div
+      ref={ref}
+      className="w-[400px] p-6 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 font-sans"
+      style={{
+        backgroundColor: currentTheme === 'dark' ? '#1F2937' : '#FFFFFF', // card-dark / card-light
+        color: textColor,
+        // Adicionar um box-sizing para garantir que padding e border não aumentem o tamanho final da imagem
+        boxSizing: 'border-box',
+      }}
+    >
+      {images?.jpg?.large_image_url ? (
+        <img
+          src={images.jpg.large_image_url}
+          alt={`Capa de ${title}`}
+          className="w-full h-48 object-cover rounded-lg mb-4 shadow-md"
+          crossOrigin="anonymous"
+        />
+      ) : (
+        <div
+          className="w-full h-48 rounded-lg mb-4 shadow-md flex items-center justify-center"
+          style={{ backgroundColor: currentTheme === 'dark' ? '#374151' : '#E5E7EB' }} // gray-700 / gray-200
+        >
+          <span style={{ color: mutedTextColor }}>Sem Imagem</span>
+        </div>
+      )}
+
+      <h2
+        className="text-2xl font-bold text-center mb-2 truncate"
+        title={title}
+        style={{ color: primaryColor }}
+      >
+        {title || 'Título do Anime'}
+      </h2>
+
+      {renderStars(rating)}
+
+      {truncatedOpinion ? (
+        <p
+          className="text-sm text-center italic my-3 p-3 rounded-md shadow-inner"
+          style={{ backgroundColor: opinionBgColor, color: textColor }}
+        >
+          "{truncatedOpinion}"
+        </p>
+      ) : (
+         <p
+            className="text-sm text-center italic my-3 p-3"
+            style={{ color: mutedTextColor }}
+         >
+          Nenhuma opinião fornecida.
+        </p>
+      )}
+
+      <div className="mt-4 text-center">
+        <p className="text-xs" style={{ color: mutedTextColor }}>
+          Avaliado com <span className="font-bold" style={{ color: primaryColor }}>Anime Master</span>
+        </p>
+      </div>
+    </div>
+  );
+});
+
+ShareableReviewCard.displayName = 'ShareableReviewCard';
+
+export default ShareableReviewCard;

--- a/src/hooks/useShareReviewImage.js
+++ b/src/hooks/useShareReviewImage.js
@@ -1,0 +1,68 @@
+// src/hooks/useShareReviewImage.js
+import { useState, useCallback } from 'react';
+import html2canvas from 'html2canvas'; // Esta importação falhará se o pacote não estiver instalado
+
+export const useShareReviewImage = () => {
+  const [generatedImage, setGeneratedImage] = useState(null); // Armazenará a dataURL da imagem
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState(null);
+
+  const generateImage = useCallback(async (elementToCapture) => {
+    if (typeof html2canvas === 'undefined') {
+        const installErrorMsg = 'Biblioteca html2canvas não está disponível. Instalação falhou ou está pendente.';
+        console.error(installErrorMsg);
+        setError(installErrorMsg);
+        setIsGenerating(false); // Certifique-se de resetar o estado de geração
+        return null;
+    }
+
+    if (!elementToCapture) {
+      setError('Elemento para captura não fornecido.');
+      console.error('Elemento para captura não fornecido para html2canvas.');
+      setIsGenerating(false); // Certifique-se de resetar o estado de geração
+      return null;
+    }
+
+    setIsGenerating(true);
+    setError(null);
+    setGeneratedImage(null);
+
+    try {
+      // Opções para html2canvas para melhor qualidade e para lidar com cross-origin
+      const canvas = await html2canvas(elementToCapture, {
+        allowTaint: true,       // Permite imagens de outras origens (requer crossOrigin="anonymous" na tag img)
+        useCORS: true,          // Tenta usar CORS para carregar imagens
+        logging: false,         // Desabilitar logs do html2canvas no console
+        scale: 2,               // Aumentar a escala para melhor resolução da imagem
+        backgroundColor: null,  // Usar o fundo do elemento, ou definir um se necessário
+        // scrollX: 0, // Resetar scroll para evitar problemas de captura de viewport
+        // scrollY: 0,
+        // windowWidth: document.documentElement.offsetWidth, // Usar documentElement para largura total
+        // windowHeight: document.documentElement.offsetHeight, // Usar documentElement para altura total
+      });
+      const imageDataUrl = canvas.toDataURL('image/png');
+      setGeneratedImage(imageDataUrl);
+      setIsGenerating(false);
+      return imageDataUrl;
+    } catch (err) {
+      console.error('Erro ao gerar imagem com html2canvas:', err);
+      setError('Falha ao gerar a imagem para compartilhamento.');
+      setIsGenerating(false);
+      return null;
+    }
+  }, []);
+
+  const resetImageState = useCallback(() => {
+    setGeneratedImage(null);
+    setIsGenerating(false);
+    setError(null);
+  }, []);
+
+  return {
+    generatedImage,
+    isGenerating,
+    error,
+    generateImage,
+    resetImageState,
+  };
+};


### PR DESCRIPTION
Este commit introduz a funcionalidade de permitir que você compartilhe suas avaliações de animes como uma imagem.

Principais Alterações:

1.  **Componente `ShareableReviewCard.jsx`:**
    *   Criado em `src/components/features/sharing/` para renderizar um card visualmente atraente contendo a capa do anime, título, nota em estrelas dada por você, opinião (truncada se necessário) e uma marca "Anime Master".
    *   Estilizado com TailwindCSS e preparado para ser capturado como imagem.
    *   Utiliza `React.forwardRef` e `crossOrigin="anonymous"` para compatibilidade com `html2canvas`.
    *   Aceita uma prop `currentTheme` para tentar aplicar estilos de tema claro/escuro na imagem gerada.

2.  **Hook `useShareReviewImage.js`:**
    *   Criado em `src/hooks/` para encapsular a lógica de geração de imagem com `html2canvas`.
    *   Gerencia estados para a imagem gerada (dataURL), status de carregamento e erros.
    *   Inclui opções para `html2canvas` visando melhor qualidade e tratamento de imagens cross-origin (como `allowTaint: true`, `useCORS: true`, `scale: 2`).
    *   Adicionada verificação para `html2canvas` (caso não seja instalado/importado corretamente).

3.  **Modal `SharePreviewModal.jsx`:**
    *   Criado em `src/components/features/sharing/` para a interface de pré-visualização e compartilhamento.
    *   Renderiza o `ShareableReviewCard` (de forma oculta) para ser capturado.
    *   Chama a função de geração de imagem do hook `useShareReviewImage` quando o modal é aberto.
    *   Exibe a imagem da avaliação gerada para você.
    *   Fornece botões de ação:
        *   "Baixar Imagem" (download do PNG).
        *   "Compartilhar no Twitter" (abre intenção de tweet com texto pré-definido).
        *   "Compartilhar (Nativo)" (utiliza a Web Share API para compartilhar a imagem, se suportado pelo navegador).
    *   Gerencia estados de carregamento e erro durante a geração da imagem.

4.  **Integração na `AnimeDetailPage.jsx`:**
    *   Adicionado um botão "Criar Imagem para Compartilhar" na seção de sua avaliação (visível apenas se você já salvou uma avaliação para o anime).
    *   Este botão abre o `SharePreviewModal`, passando os dados necessários do anime, da sua avaliação e do tema atual.

Esta funcionalidade visa aumentar o seu engajamento, permitindo que você compartilhe suas opiniões de forma visual nas redes sociais. A instalação local da dependência `html2canvas` é necessária para o funcionamento completo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a sharing feature for anime reviews, allowing users to generate a shareable image of their review.
	- Added a modal interface for previewing and sharing review images, with options to download, share on Twitter, or use native sharing if supported.
	- Enhanced the anime review page with a new "Share Review" section for easy access to sharing tools.
- **Bug Fixes**
	- None.
- **Documentation**
	- None.
- **Refactor**
	- None.
- **Style**
	- None.
- **Tests**
	- None.
- **Chores**
	- None.
- **Revert**
	- None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->